### PR TITLE
fix: support robust NuGetize pack delegation for PackFolder=build projects

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -39,7 +39,7 @@
     <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == ''">$(MSBuildSDKsPath)\..\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
   </PropertyGroup>
 
-  <Import Project="$(NuGetBuildTasksPackTargets)" Condition="Exists('$(NuGetBuildTasksPackTargets)')"/>
+  <Import Project="$(NuGetBuildTasksPackTargets)" Condition="Exists('$(NuGetBuildTasksPackTargets)') And '$(NuGetize)' != 'true'" />
 
   <PropertyGroup>
     <!-- Revert the forced PackageId by the NuGet SDK targets for non-packable projects, see https://github.com/NuGet/Home/issues/14928 -->


### PR DESCRIPTION
### Problem
Projects using NuGetizer + `PackFolder=build` (the standard way to author MSBuild/ tool packages) would get their assets incorrectly placed under `content/` + `contentFiles/` when packed via `dotnet pack`.

This is the same root cause that affected the nugetizer 1.4.8 release.

### Root cause
- The shared `Directory.Build.targets` always imported the real `NuGet.Build.Tasks.Pack.targets`.
- "dotnet pack" flows did not reliably go through the `NuGetize=true` path.
- Result: SDK pack defaults won instead of NuGetizer's `PackFolder` inference.

### Fix
* Condition the import of the real pack targets: `And '$(NuGetize)' != 'true'`. When a project opts into NuGetizer via `NuGetize`, don't pull in the conflicting SDK pack targets.
* Add a late `<Target Name="Pack">` delegator (after the pack import) that, for any project with `PackFolder=build` or `buildTransitive`, re-invokes MSBuild with `NuGetize=true`. This guarantees the correct packaging logic runs.

The delegator is declared late in the file so it takes precedence.

See also the consuming change in https://github.com/devlooped/nugetizer/pull/726
